### PR TITLE
Change pkgdown.yml to non-tidytemplate

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,4 @@
-template:
-  package: tidytemplate
-  default_assets: false
+url: https://here.r-lib.org
 
 home:
   strip_header: true


### PR DESCRIPTION
* Builds so that it should take care of #25, but if I run pkgdown locally, the paths end up being `maraaverick/~` rather than `travis`.