### PR TITLE
docs: fixed "heuristics" typo

### DIFF
--- a/R/here.R
+++ b/R/here.R
@@ -1,6 +1,6 @@
 #' Find your files
 #'
-#' `here()` uses a reasonable heuristics to find your project's files, based on
+#' `here()` uses reasonable heuristics to find your project's files, based on
 #' the current working directory at the time when the package is loaded.
 #' Use it as a drop-in replacement for [file.path()], it will always locate the
 #' files relative to your project root.

--- a/man/here.Rd
+++ b/man/here.Rd
@@ -13,7 +13,7 @@ Each argument should be a string containing one or more
 path components separated by a forward slash \code{"/"}.}
 }
 \description{
-\code{here()} uses a reasonable heuristics to find your project's files, based on
+\code{here()} uses reasonable heuristics to find your project's files, based on
 the current working directory at the time when the package is loaded.
 Use it as a drop-in replacement for \code{\link[=file.path]{file.path()}}, it will always locate the
 files relative to your project root.


### PR DESCRIPTION
Fixed a small typo (grammatical error) I noticed in the documentation.