### PR TITLE
fix broken link in `here.Rmd` vignette

### DIFF
--- a/vignettes/here.Rmd
+++ b/vignettes/here.Rmd
@@ -21,7 +21,7 @@ The here package enables easy file referencing by using the top-level directory 
 This is in contrast to using `setwd()`, which is fragile and dependent on the way you order your files on your computer.
 Read more about project-oriented workflows:
 
-- What They Forgot to Teach You About R: ["Project-oriented workflow"](https://rstats.wtf/project-oriented-workflow.html) chapter by Jenny Bryan and Jim Hester
+- What They Forgot to Teach You About R: ["Project-oriented workflow"](https://rstats.wtf/projects.html) chapter by Jenny Bryan and Jim Hester
 
 - ["Project-oriented workflow"](https://www.tidyverse.org/blog/2017/12/workflow-vs-script/) blog post by Jenny Bryan
 


### PR DESCRIPTION
Good afternoon maintainers,

Apologies for the PR without an issue. I was about to share the `{here}` pkgdown site with a colleague and noted that there was a broken link in the vignette.

This PR effectively implements the previous change in the README (https://github.com/r-lib/here/commit/9853b8ae447707fc29dcddcefb21a27b2a80403b), but in the `here.Rmd` vignette.

Best,
Jack