### PR TITLE
fledge: CRAN release v1.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: here
 Title: A Simpler Way to Find Your Files
-Version: 1.0.1.9036
+Version: 1.0.2
 Date: 2025-09-06
 Authors@R: 
     c(person(given = "Kirill",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,105 +8,13 @@
 
 ## Chore
 
-- Auto-update from GitHub Actions (#145).
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-lib/here/actions/runs/14636203620
-
-  Run: https://github.com/r-lib/here/actions/runs/10425486329
-
-  Run: https://github.com/r-lib/here/actions/runs/10200110394
-
-  Run: https://github.com/r-lib/here/actions/runs/9728440182
-
-  Run: https://github.com/r-lib/here/actions/runs/9691616332
-
-- Add Aviator configuration.
-
 - Change maintainer e-mail.
-
-## Continuous integration
-
-- Use reviewdog for external PRs (#147).
-
-- Cleanup and fix macOS (#136).
-
-- Format with air, check detritus, better handling of `extra-packages` (#133).
-
-- Enhance permissions for workflow (#124).
-
-- Permissions, better tests for missing suggests, lints (#123).
-
-- Only fail covr builds if token is given (#122).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#121).
-
-- Correct installation of xml2 (#120).
-
-- Explain (#119).
-
-- Add xml2 for covr, print testthat results (#118).
-
-- Fix (#117).
-
-- Sync (#116).
-
-- Avoid failure in fledge workflow if no changes (#114).
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#113).
-
-- Use stable pak (#112).
-
-- Latest changes (#111).
-
-- Trigger run (#110).
-
-- Use pkgdown branch (#109).
-
-  - ci: Use pkgdown branch
-
-  - ci: Updates from duckdb
-
-  - ci: Trigger run
-
-- Install via R CMD INSTALL ., not pak (#108).
-
-  - ci: Install via R CMD INSTALL ., not pak
-
-  - ci: Bump version of upload-artifact action
-
-- Install local package for pkgdown builds.
-
-- Improve support for protected branches with fledge.
-
-- Improve support for protected branches, without fledge.
-
-- Sync with latest developments.
-
-- Use v2 instead of master.
-
-- Import from actions-sync, check carefully.
 
 ## Documentation
 
 - Fix link to "What they forgot" chapter (@Masterxilo, #101).
 
 - Fixed "heuristics" typo (@t-gummer, #91).
-
-## Uncategorized
-
-- Merge branch 'docs'.
-
-- Internal changes only.
-
-- Merge pull request #103 from jack-davison/patch-1.
-
-  fix broken link in `here.Rmd` vignette
-
-- Merge cran-1.0.1.
-
-- Adapt to testthat 3.0.1.
 
 
 # here 1.0.1 (2020-12-13)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,84 +1,48 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# here 1.0.1.9036 (2025-09-06)
-
-## Continuous integration
-
-- Use reviewdog for external PRs (#147).
-
-
-# here 1.0.1.9035 (2025-09-05)
-
-## Chore
-
-- Auto-update from GitHub Actions (#145).
-
-
-# here 1.0.1.9034 (2025-08-29)
+# here 1.0.2 (2025-09-14)
 
 ## Features
 
 - Discover VS Code, Quarto and renv projects (#128, #130).
 
-
-# here 1.0.1.9033 (2025-08-05)
-
-## Continuous integration
-
-- Cleanup and fix macOS (#136).
-
-
-# here 1.0.1.9032 (2025-08-01)
-
-## Continuous integration
-
-- Format with air, check detritus, better handling of `extra-packages` (#133).
-
-
-# here 1.0.1.9031 (2025-07-13)
-
-- Merge branch 'docs'.
-
-
-# here 1.0.1.9030 (2025-05-04)
-
-## Continuous integration
-
-- Enhance permissions for workflow (#124).
-
-
-# here 1.0.1.9029 (2025-04-30)
-
-## Continuous integration
-
-- Permissions, better tests for missing suggests, lints (#123).
-
-
-# here 1.0.1.9028 (2025-04-28)
-
-## Continuous integration
-
-- Only fail covr builds if token is given (#122).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#121).
-
-
-# here 1.0.1.9027 (2025-04-26)
-
-## Continuous integration
-
-- Correct installation of xml2 (#120).
-
-
-# here 1.0.1.9026 (2025-04-25)
-
 ## Chore
+
+- Auto-update from GitHub Actions (#145).
 
 - Auto-update from GitHub Actions.
 
   Run: https://github.com/r-lib/here/actions/runs/14636203620
 
+  Run: https://github.com/r-lib/here/actions/runs/10425486329
+
+  Run: https://github.com/r-lib/here/actions/runs/10200110394
+
+  Run: https://github.com/r-lib/here/actions/runs/9728440182
+
+  Run: https://github.com/r-lib/here/actions/runs/9691616332
+
+- Add Aviator configuration.
+
+- Change maintainer e-mail.
+
 ## Continuous integration
+
+- Use reviewdog for external PRs (#147).
+
+- Cleanup and fix macOS (#136).
+
+- Format with air, check detritus, better handling of `extra-packages` (#133).
+
+- Enhance permissions for workflow (#124).
+
+- Permissions, better tests for missing suggests, lints (#123).
+
+- Only fail covr builds if token is given (#122).
+
+- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#121).
+
+- Correct installation of xml2 (#120).
 
 - Explain (#119).
 
@@ -88,207 +52,59 @@
 
 - Sync (#116).
 
-
-# here 1.0.1.9025 (2024-12-09)
-
-## Continuous integration
-
 - Avoid failure in fledge workflow if no changes (#114).
-
-
-# here 1.0.1.9024 (2024-12-08)
-
-## Continuous integration
 
 - Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#113).
 
-
-# here 1.0.1.9023 (2024-12-07)
-
-## Continuous integration
-
 - Use stable pak (#112).
 
+- Latest changes (#111).
 
-# here 1.0.1.9022 (2024-11-10)
+- Trigger run (#110).
 
-## Continuous integration
+- Use pkgdown branch (#109).
 
-  - Latest changes (#111).
+  - ci: Use pkgdown branch
 
+  - ci: Updates from duckdb
 
-# here 1.0.1.9021 (2024-10-28)
+  - ci: Trigger run
 
-## Continuous integration
+- Install via R CMD INSTALL ., not pak (#108).
 
-  - Trigger run (#110).
+  - ci: Install via R CMD INSTALL ., not pak
 
-  - Use pkgdown branch (#109).
-    
-      - ci: Use pkgdown branch
-    
-      - ci: Updates from duckdb
-    
-      - ci: Trigger run
+  - ci: Bump version of upload-artifact action
 
+- Install local package for pkgdown builds.
 
-# here 1.0.1.9020 (2024-09-15)
+- Improve support for protected branches with fledge.
 
-## Continuous integration
-
-  - Install via R CMD INSTALL ., not pak (#108).
-    
-      - ci: Install via R CMD INSTALL ., not pak
-    
-      - ci: Bump version of upload-artifact action
-
-
-# here 1.0.1.9019 (2024-08-31)
-
-## Continuous integration
-
-  - Install local package for pkgdown builds.
-
-  - Improve support for protected branches with fledge.
-
-  - Improve support for protected branches, without fledge.
-
-
-# here 1.0.1.9018 (2024-08-17)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-lib/here/actions/runs/10425486329
-
-## Continuous integration
+- Improve support for protected branches, without fledge.
 
 - Sync with latest developments.
 
-
-# here 1.0.1.9017 (2024-08-10)
-
-## Continuous integration
-
 - Use v2 instead of master.
 
-
-# here 1.0.1.9016 (2024-08-06)
-
-## Continuous integration
-
 - Import from actions-sync, check carefully.
-
-
-# here 1.0.1.9015 (2024-08-02)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-lib/here/actions/runs/10200110394
-
-## Continuous integration
-
-- Import from actions-sync, check carefully.
-
-
-# here 1.0.1.9014 (2024-07-02)
-
-- Internal changes only.
-
-
-# here 1.0.1.9013 (2024-06-30)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-lib/here/actions/runs/9728440182
-
-
-# here 1.0.1.9012 (2024-06-28)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-lib/here/actions/runs/9691616332
-
-
-# here 1.0.1.9011 (2024-01-27)
-
-## Chore
-
-- Add Aviator configuration.
-
-## Uncategorized
-
-- Merge pull request #103 from jack-davison/patch-1.
-
-  fix broken link in `here.Rmd` vignette
-
-
-# here 1.0.1.9010 (2024-01-24)
-
-- Internal changes only.
-
-
-# here 1.0.1.9009 (2024-01-15)
-
-- Internal changes only.
-
-
-# here 1.0.1.9008 (2024-01-01)
 
 ## Documentation
 
 - Fix link to "What they forgot" chapter (@Masterxilo, #101).
 
-
-# here 1.0.1.9007 (2023-10-10)
-
-- Internal changes only.
-
-
-# here 1.0.1.9006 (2023-10-09)
-
-- Internal changes only.
-
-
-# here 1.0.1.9005 (2023-03-24)
-
-- Internal changes only.
-
-
-# here 1.0.1.9004 (2023-02-17)
-
-- Internal changes only.
-
-
-# here 1.0.1.9003 (2023-02-07)
-
-## Chore
-
-- Change maintainer e-mail.
-
-## Documentation
-
 - Fixed "heuristics" typo (@t-gummer, #91).
 
+## Uncategorized
 
-# here 1.0.1.9002 (2022-12-30)
+- Merge branch 'docs'.
 
 - Internal changes only.
 
+- Merge pull request #103 from jack-davison/patch-1.
 
-# here 1.0.1.9001 (2022-12-24)
+  fix broken link in `here.Rmd` vignette
 
 - Merge cran-1.0.1.
-
-
-# here 1.0.1.9000 (2020-12-13)
 
 - Adapt to testthat 3.0.1.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,10 +58,10 @@ rlang::local_interactive(FALSE)
 # here
 
 <!-- badges: start -->
-[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![rcc](https://github.com/r-lib/here/workflows/rcc/badge.svg)](https://github.com/r-lib/here/actions)
 [![CRAN status](https://www.r-pkg.org/badges/version/here)](https://CRAN.R-project.org/package=here)
-[![Codecov test coverage](https://codecov.io/gh/r-lib/here/branch/main/graph/badge.svg)](https://codecov.io/gh/r-lib/here?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/r-lib/here/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/here?branch=main)
 <!-- badges: end -->
 
 The goal of the here package is to enable easy file referencing in [project-oriented workflows](https://rstats.wtf/projects.html).

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 <!-- badges: start -->
 
 [![Lifecycle:
-stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![rcc](https://github.com/r-lib/here/workflows/rcc/badge.svg)](https://github.com/r-lib/here/actions)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/here)](https://CRAN.R-project.org/package=here)
 [![Codecov test
-coverage](https://codecov.io/gh/r-lib/here/branch/main/graph/badge.svg)](https://codecov.io/gh/r-lib/here?branch=main)
+coverage](https://codecov.io/gh/r-lib/here/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/here?branch=main)
 <!-- badges: end -->
 
 The goal of the here package is to enable easy file referencing in

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,7 @@
-here 1.0.1: Compatibility with testthat 3.0.1
+here 1.0.2
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2020-10-29.
+- [ ] Reviewed CRP last edited 2024-08-27.
 
-## R CMD check results
-
-- [x] Checked locally, R 4.0.3
-- [x] Checked on CI system, R 4.0.3
-- [x] Checked on win-builder, R devel
-
-## Current CRAN check results
-
-- [x] Checked on 2020-12-13, no problems found.
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2020-10-29%7D...master@%7B2024-08-27%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ here 1.0.2
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2024-08-27.
+- [x] Reviewed CRP last edited 2024-08-27.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2020-10-29%7D...master@%7B2024-08-27%7D

--- a/vignettes/here.Rmd
+++ b/vignettes/here.Rmd
@@ -236,7 +236,7 @@ In the future, a helper function will assist with installing and updating suitab
 
 ### Change project root
 
-It is advisable to [start a fresh R session](https://rstats.wtf/save-source.html) as often as possible, especially before focusing on another project.
+It is advisable to [start a fresh R session](https://rstats.wtf/source-and-blank-slates) as often as possible, especially before focusing on another project.
 There still may be legitimate cases when it is desirable to reset the project root.
 
 To start, let's create a temporary project for demonstration:


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-09-14, problems found: https://cran.r-project.org/web/checks/check_results_here.html
- [ ] NOTE: r-oldrel-macos-arm64, r-oldrel-macos-x86_64, r-oldrel-windows-x86_64
     'LazyData' is specified without a 'data' directory

Check results at: https://cran.r-project.org/web/checks/check_results_here.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`